### PR TITLE
perf: let cached source work right

### DIFF
--- a/src/cached_source.rs
+++ b/src/cached_source.rs
@@ -7,7 +7,13 @@ use std::{
 use dashmap::DashMap;
 use rustc_hash::FxHasher;
 
-use crate::{helpers::{stream_and_get_source_and_map, stream_chunks_of_raw_source, stream_chunks_of_source_map, StreamChunks}, MapOptions, Source, SourceMap};
+use crate::{
+  helpers::{
+    stream_and_get_source_and_map, stream_chunks_of_raw_source,
+    stream_chunks_of_source_map, StreamChunks,
+  },
+  MapOptions, Source, SourceMap,
+};
 
 /// It tries to reused cached results from other methods to avoid calculations,
 /// usually used after modify is finished.
@@ -123,7 +129,13 @@ impl<T: Source + Hash + PartialEq + Eq + 'static> StreamChunks
         );
       }
     }
-    let (generated_info, map) = stream_and_get_source_and_map(self.original(), options, on_chunk, on_source, on_name);
+    let (generated_info, map) = stream_and_get_source_and_map(
+      self.original(),
+      options,
+      on_chunk,
+      on_source,
+      on_name,
+    );
     self.cached_maps.insert(options.clone(), map);
     generated_info
   }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1506,6 +1506,16 @@ pub fn stream_and_get_source_and_map<S: StreamChunks>(
   );
 
   let mappings = encode_mappings(&mappings, options);
-  let map = if mappings.is_empty() { None } else { Some(SourceMap::new(None, mappings, sources, sources_content, names)) };
+  let map = if mappings.is_empty() {
+    None
+  } else {
+    Some(SourceMap::new(
+      None,
+      mappings,
+      sources,
+      sources_content,
+      names,
+    ))
+  };
   (generated_info, map)
 }


### PR DESCRIPTION
Implement caching in the `stream_chunks` function of `CachedSource` to accelerate source map generation significantly.

Previously, generating a source map for a file in a real-world project took about 4.5 seconds during the **HMR** phase.:

![image](https://github.com/web-infra-dev/rspack-sources/assets/19852293/b45b5b4e-7c53-47ea-8b07-d911aee98f09)

With caching, the source map generation time has been reduced dramatically to approximately 0.2 seconds:

![image](https://github.com/web-infra-dev/rspack-sources/assets/19852293/12836719-bd2b-40a5-acb1-9554d2bf29b9)
