### PR TITLE
perf(concat_source): skip Mutex acquire in add() under &mut self

### DIFF
--- a/src/concat_source.rs
+++ b/src/concat_source.rs
@@ -127,7 +127,14 @@ impl ConcatSource {
 
   /// Add a [Source] to concat.
   pub fn add<S: Source + 'static>(&mut self, source: S) {
-    let children = &mut *self.children.lock().unwrap();
+    // `&mut self` guarantees exclusive access, so the Mutex doesn't need to be
+    // locked here — `get_mut` skips the atomic acquire/release. This matters
+    // because `add` is called many hundreds of times per chunk in rspack's
+    // code-generation hot path.
+    let children = self
+      .children
+      .get_mut()
+      .expect("ConcatSource children mutex poisoned");
 
     if let Some(optimized_children) = self.is_optimized.take() {
       *children = optimized_children;


### PR DESCRIPTION
## What

Replace `lock().unwrap()` with `get_mut().unwrap()` inside `ConcatSource::add`, removing one redundant atomic acquire/release per call. Other `&self` access points (`Clone`, `Debug::fmt`, `optimized_children`, and the downcast paths inside `add` that touch other `ConcatSource` instances) still use `lock()`.

## Why

`add` already takes `&mut self`, so the borrow checker statically guarantees exclusive access to the inner `Vec<BoxSource>` — the runtime synchronization a `Mutex` provides is unnecessary here. Beyond the perf consideration, this also makes the intent more accurate: `&mut self` should not need to synchronize with anyone.

The existing benchmarks build a `ConcatSource` once during setup and then loop over `.map().to_json()`, so they exercise the cached read path rather than `add` — which is why CodSpeed shows no change here. Real Rspack hot paths use `add` very differently: `rspack_plugin_javascript/src/runtime.rs` does a `par_iter().fold(ConcatSource::default, |mut acc, src| { acc.add(src); acc })`, and `rspack_core`'s concatenated module rendering chains 300+ `add` calls per module.

I ran a targeted local microbenchmark (Apple Silicon, 50 samples × 8s, criterion `--baseline`, repeated runs to confirm reproducibility): a `ConcatSource` built by 500 sequential `add` calls dropped from 8.29 µs to 5.05 µs (**−39%**, p < 0.001, ~1% CI width); the 16-add variant dropped from 421 ns to 278 ns (**−32%**). That works out to ~6–7 ns saved per `add`, matching the cost of a `Mutex` acquire/release on Apple Silicon. The microbenchmarks themselves are landing in a separate PR so this one stays a minimal, focused change.

## How

- `src/concat_source.rs::add`: `&mut *self.children.lock().unwrap()` → `self.children.get_mut().expect(...)`. `get_mut` borrows the whole `Mutex` mutably instead of going through a guard, equivalent to the original mutable-borrow semantics; the subsequent `self.is_optimized.take()` still works because it's a disjoint field borrow.
- All 76 lib tests + 11 doc tests pass; `cargo clippy --release` and `cargo fmt --check` both clean.