### PR TITLE
test(bench): add concat_source_add microbenchmark

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,8 +13,9 @@ pub use criterion::*;
 pub use codspeed_criterion_compat::*;
 
 use rspack_sources::{
-  BoxSource, CachedSource, ConcatSource, MapOptions, ObjectPool, Source,
-  SourceExt, SourceMap, SourceMapSource, SourceMapSourceOptions,
+  BoxSource, CachedSource, ConcatSource, MapOptions, ObjectPool,
+  RawStringSource, Source, SourceExt, SourceMap, SourceMapSource,
+  SourceMapSourceOptions,
 };
 
 use bench_complex_replace_source::{
@@ -142,6 +143,38 @@ fn benchmark_cached_source_hash(b: &mut Bencher) {
   })
 }
 
+fn benchmark_concat_source_add_many(b: &mut Bencher) {
+  // Mimic rspack's concatenated_module / runtime hot path: build a ConcatSource
+  // by adding many small children sequentially. 500 matches the scale of a
+  // typical concatenated module (rspack chains 300+ adds per module).
+  let pieces: Vec<BoxSource> = (0..500)
+    .map(|i| RawStringSource::from(format!("// piece {i}\n")).boxed())
+    .collect();
+
+  b.iter(|| {
+    let mut concat = ConcatSource::default();
+    for piece in &pieces {
+      concat.add(piece.clone());
+    }
+    std::hint::black_box(concat);
+  })
+}
+
+fn benchmark_concat_source_add_few(b: &mut Bencher) {
+  // Smaller scale: closer to runtime module assembly (~10-15 adds per chunk).
+  let pieces: Vec<BoxSource> = (0..16)
+    .map(|i| RawStringSource::from(format!("// piece {i}\n")).boxed())
+    .collect();
+
+  b.iter(|| {
+    let mut concat = ConcatSource::default();
+    for piece in &pieces {
+      concat.add(piece.clone());
+    }
+    std::hint::black_box(concat);
+  })
+}
+
 fn bench_rspack_sources(criterion: &mut Criterion) {
   let mut group = criterion.benchmark_group("rspack_sources");
 
@@ -153,6 +186,11 @@ fn bench_rspack_sources(criterion: &mut Criterion) {
     .bench_function("concat_generate_string", benchmark_concat_generate_string);
 
   group.bench_function("cached_source_hash", benchmark_cached_source_hash);
+
+  group
+    .bench_function("concat_source_add_many", benchmark_concat_source_add_many);
+  group
+    .bench_function("concat_source_add_few", benchmark_concat_source_add_few);
 
   group.bench_function(
     "complex_replace_source_map",


### PR DESCRIPTION
## What

Adds two new criterion benchmarks under the existing `rspack_sources` group:

- `concat_source_add_many` — builds a `ConcatSource` by sequentially adding 500 `RawStringSource` children
- `concat_source_add_few` — same shape, but with 16 children

## Why

The current bench suite builds each `ConcatSource` once during setup and then loops over `.map().to_json()` (or `.source()`, `.size()`, hashing, etc.) inside `b.iter`. That measures the cached read path, but leaves the construction path — the repeated `add` calls — completely uninstrumented.

In real Rspack code generation, `add` is one of the hottest patterns: `rspack_plugin_javascript/src/runtime.rs` does a `par_iter().fold(ConcatSource::default, |mut acc, src| { acc.add(src); acc })`, and `rspack_core`'s concatenated module rendering chains 300+ `add` calls per module. Without coverage here, perf changes touching `add` (good or bad) slip past CodSpeed silently — for example, the recent `lock()` → `get_mut()` change in `add` showed no movement on the existing benches even though it's measurably ~6–7 ns faster per call.

The 500/16 sizes were picked to match those two real shapes (concatenated module assembly vs. runtime module wrapping).

## How

- `benches/bench.rs`: two new functions, each building `Vec<BoxSource>` of N `RawStringSource` children up-front (so allocation is excluded from the hot loop), then `b.iter` builds a fresh `ConcatSource` and adds them all.
- Registered in the existing `rspack_sources` benchmark group alongside the others.
- No production code changes.