### PR TITLE
fix: unpin rkyv dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ codspeed-criterion-compat = { version = "4.6.0", default-features = false, optio
 static_assertions = "1.1.0"
 simd-json = "0.17.0"
 simd-utf16-len = "0.1.0"
-rkyv = { version = "=0.8.16", default-features = false, features = ["std", "bytecheck"], optional = true }
+rkyv = { version = "0.8.16", default-features = false, features = ["std", "bytecheck"], optional = true }
 
 [dev-dependencies]
 twox-hash = "2.1.2"


### PR DESCRIPTION
## Summary

- Relax the optional `rkyv` dependency from an exact `=0.8.16` requirement to the normal compatible `0.8.16` range.
- Keep the existing `default-features = false` and `std`/`bytecheck` feature selection unchanged.

## Impact

This allows compatible `0.8.x` patch updates of `rkyv` to resolve without requiring a source change in this crate.

## Validation

- `cargo check --features rspack_cacheable`