### PR TITLE
[codex] chore: release 0.4.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspack_sources"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 authors = ["h-a-n-a <andywangsy@gmail.com>", "ahabhgk <ahabhgk@gmail.com>"]
 resolver = "2"


### PR DESCRIPTION
## Summary

- Bump `rspack_sources` package version from `0.4.22` to `0.4.23`.
- Update the matching `Cargo.lock` package entry.

## Validation

- `cargo check --features rspack_cacheable`