### PR TITLE
perf: optimize source map generation

### DIFF
--- a/src/cached_source.rs
+++ b/src/cached_source.rs
@@ -21,6 +21,7 @@ struct CachedData {
   hash: OnceLock<u64>,
   size: OnceLock<usize>,
   is_ascii: OnceLock<bool>,
+  source: OnceLock<String>,
   chunks: OnceLock<Vec<&'static str>>,
   columns_map: OnceLock<Option<SourceMap>>,
   line_only_map: OnceLock<Option<SourceMap>>,
@@ -104,10 +105,35 @@ impl CachedSource {
 
   fn is_ascii(&self) -> bool {
     *self.cache.is_ascii.get_or_init(|| {
+      if let Some(source) = self.cache.source.get() {
+        return source.is_ascii();
+      }
       if let Some(chunks) = self.cache.chunks.get() {
         return chunks.iter().all(|chunk| chunk.is_ascii());
       }
       self.inner.source().as_bytes().is_ascii()
+    })
+  }
+
+  fn get_or_init_source(&self) -> &str {
+    self.cache.source.get_or_init(|| {
+      let chunks = self.get_or_init_chunks();
+      let mut string = String::with_capacity(self.size());
+      if self.cache.is_ascii.get().is_none() {
+        let mut is_ascii = true;
+        for chunk in chunks {
+          if is_ascii {
+            is_ascii = chunk.is_ascii();
+          }
+          string.push_str(chunk);
+        }
+        let _ = self.cache.is_ascii.set(is_ascii);
+      } else {
+        for chunk in chunks {
+          string.push_str(chunk);
+        }
+      }
+      string
     })
   }
 }
@@ -124,23 +150,7 @@ impl Source for CachedSource {
       return buffer_source.source();
     }
 
-    let chunks = self.get_or_init_chunks();
-    let mut string = String::with_capacity(self.size());
-    if self.cache.is_ascii.get().is_none() {
-      let mut is_ascii = true;
-      for chunk in chunks {
-        if is_ascii {
-          is_ascii = chunk.is_ascii();
-        }
-        string.push_str(chunk);
-      }
-      let _ = self.cache.is_ascii.set(is_ascii);
-    } else {
-      for chunk in chunks {
-        string.push_str(chunk);
-      }
-    }
-    SourceValue::String(Cow::Owned(string))
+    SourceValue::String(Cow::Borrowed(self.get_or_init_source()))
   }
 
   fn rope<'a>(&'a self, on_chunk: &mut dyn FnMut(&'a str)) {
@@ -188,21 +198,14 @@ impl Source for CachedSource {
 
 struct CachedSourceChunks<'source> {
   chunks: Box<dyn Chunks + 'source>,
-  cache: Arc<CachedData>,
-  source: Cow<'source, str>,
-  is_ascii: bool,
+  cache_source: &'source CachedSource,
 }
 
 impl<'a> CachedSourceChunks<'a> {
   fn new(cache_source: &'a CachedSource) -> Self {
-    let source = cache_source.source().into_string_lossy();
-    let is_ascii = cache_source.is_ascii();
-
     Self {
       chunks: cache_source.inner.stream_chunks(),
-      cache: cache_source.cache.clone(),
-      source,
-      is_ascii,
+      cache_source,
     }
   }
 }
@@ -217,13 +220,15 @@ impl Chunks for CachedSourceChunks<'_> {
     on_name: crate::helpers::OnName<'_, 'a>,
   ) -> GeneratedInfo {
     let cell = if options.columns {
-      &self.cache.columns_map
+      &self.cache_source.cache.columns_map
     } else {
-      &self.cache.line_only_map
+      &self.cache_source.cache.line_only_map
     };
     match cell.get() {
       Some(map) => {
-        let source = TextSpan::with_known(self.source.as_ref(), self.is_ascii);
+        let source = self.cache_source.get_or_init_source();
+        let is_ascii = self.cache_source.is_ascii();
+        let source = TextSpan::with_known(source, is_ascii);
         if let Some(map) = map {
           stream_chunks_of_source_map(
             options,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,6 @@
 use crate::Mapping;
 
-const B64_CHARS: &[u8] =
+const B64_CHARS: &[u8; 64] =
   b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 #[inline(always)]
@@ -10,7 +10,7 @@ pub fn encode_vlq(out: &mut Vec<u8>, a: u32, b: u32) {
     return;
   }
 
-  let mut num = if a >= b {
+  let mut num = if a > b {
     (a - b) << 1
   } else {
     ((b - a) << 1) + 1
@@ -90,7 +90,7 @@ impl FullMappingsEncoder {
       active_mapping: false,
       active_name: false,
       initial: true,
-      mappings: Default::default(),
+      mappings: Vec::with_capacity(256),
     }
   }
 }
@@ -98,24 +98,23 @@ impl FullMappingsEncoder {
 impl FullMappingsEncoder {
   #[inline(always)]
   fn encode(&mut self, mapping: &Mapping) {
+    let original = mapping.original.as_ref();
     if self.active_mapping && self.current_line == mapping.generated_line {
       // A mapping is still active
-      if mapping.original.as_ref().is_some_and(|original| {
-        original.source_index == self.current_source_index
+      if let Some(original) = original {
+        if original.source_index == self.current_source_index
           && original.original_line == self.current_original_line
           && original.original_column == self.current_original_column
           && !self.active_name
           && original.name_index.is_none()
-      }) {
-        // avoid repeating the same original mapping
-        return;
+        {
+          // avoid repeating the same original mapping
+          return;
+        }
       }
-    } else {
-      // No mapping is active
-      if mapping.original.is_none() {
-        // avoid writing unnecessary generated mappings
-        return;
-      }
+    } else if original.is_none() {
+      // No mapping is active: avoid writing unnecessary generated mappings
+      return;
     }
 
     if self.current_line < mapping.generated_line {
@@ -136,7 +135,7 @@ impl FullMappingsEncoder {
       self.current_column,
     );
     self.current_column = mapping.generated_column;
-    if let Some(original) = &mapping.original {
+    if let Some(original) = original {
       self.active_mapping = true;
       if original.source_index == self.current_source_index {
         self.mappings.push(b'A');
@@ -205,7 +204,7 @@ impl LinesOnlyMappingsEncoder {
       current_line: 1,
       current_source_index: 0,
       current_original_line: 1,
-      mappings: Default::default(),
+      mappings: Vec::with_capacity(64),
     }
   }
 }

--- a/src/replace_source.rs
+++ b/src/replace_source.rs
@@ -636,6 +636,16 @@ impl Chunks for ReplaceSourceChunks<'_> {
     on_source: crate::helpers::OnSource<'_, 'a>,
     on_name: crate::helpers::OnName<'_, 'a>,
   ) -> crate::helpers::GeneratedInfo {
+    if self.replacements.is_empty() {
+      return self.chunks.stream(
+        object_pool,
+        options,
+        on_chunk,
+        on_source,
+        on_name,
+      );
+    }
+
     let on_name = RefCell::new(on_name);
     let repls = &self.replacements;
     let mut pos: u32 = 0;

--- a/src/source.rs
+++ b/src/source.rs
@@ -583,7 +583,37 @@ impl SourceMap {
   pub fn to_json(&self) -> String {
     let mut buffer = Vec::with_capacity(self.json_size_hint());
 
-    simd_json::to_writer(&mut buffer, self).unwrap();
+    buffer.extend_from_slice(br#"{"version":3"#);
+    if let Some(file) = &self.file {
+      buffer.extend_from_slice(br#","file":"#);
+      simd_json::to_writer(&mut buffer, file.as_ref()).unwrap();
+    }
+    buffer.extend_from_slice(br#","sources":"#);
+    write_json_str_array(&mut buffer, self.sources.iter().map(String::as_str));
+    if !is_all_empty(&self.sources_content) {
+      buffer.extend_from_slice(br#","sourcesContent":"#);
+      write_json_str_array(
+        &mut buffer,
+        self.sources_content.iter().map(Arc::as_ref),
+      );
+    }
+    buffer.extend_from_slice(br#","names":"#);
+    write_json_str_array(&mut buffer, self.names.iter().map(String::as_str));
+    buffer.extend_from_slice(br#","mappings":"#);
+    write_mappings_json_str(&mut buffer, self.mappings.as_ref());
+    if let Some(source_root) = &self.source_root {
+      buffer.extend_from_slice(br#","sourceRoot":"#);
+      simd_json::to_writer(&mut buffer, source_root.as_ref()).unwrap();
+    }
+    if let Some(debug_id) = &self.debug_id {
+      buffer.extend_from_slice(br#","debugId":"#);
+      simd_json::to_writer(&mut buffer, debug_id.as_ref()).unwrap();
+    }
+    if let Some(ignore_list) = &self.ignore_list {
+      buffer.extend_from_slice(br#","ignoreList":"#);
+      simd_json::to_writer(&mut buffer, ignore_list).unwrap();
+    }
+    buffer.push(b'}');
 
     // SAFETY: simd_json always produces valid UTF-8 JSON
     #[allow(unsafe_code)]
@@ -591,6 +621,34 @@ impl SourceMap {
       String::from_utf8_unchecked(buffer)
     }
   }
+}
+
+#[inline]
+fn write_json_str_array<'a>(
+  buffer: &mut Vec<u8>,
+  iter: impl Iterator<Item = &'a str>,
+) {
+  buffer.push(b'[');
+  for (i, item) in iter.enumerate() {
+    if i != 0 {
+      buffer.push(b',');
+    }
+    simd_json::to_writer(&mut *buffer, item).unwrap();
+  }
+  buffer.push(b']');
+}
+
+#[inline]
+fn write_mappings_json_str(buffer: &mut Vec<u8>, mappings: &str) {
+  debug_assert!(
+    mappings
+      .bytes()
+      .all(|b| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/' | b',' | b';')),
+    "source map mappings must be VLQ/base64 text"
+  );
+  buffer.push(b'"');
+  buffer.extend_from_slice(mappings.as_bytes());
+  buffer.push(b'"');
 }
 
 impl TryFrom<RawSourceMap> for SourceMap {

--- a/src/source_content_lines.rs
+++ b/src/source_content_lines.rs
@@ -17,8 +17,15 @@ impl<'object_pool> SourceContentLines<'object_pool> {
     #[allow(unsafe_code)]
     let text_ref =
       unsafe { std::mem::transmute::<&str, &'static str>(text.as_ref()) };
+    let is_ascii = text_ref.is_ascii();
     let lines = split_into_lines(text_ref)
-      .map(|line| WithUtf16::new(object_pool, line))
+      .map(|line| {
+        if is_ascii {
+          WithUtf16::with_known(object_pool, line, true)
+        } else {
+          WithUtf16::new(object_pool, line)
+        }
+      })
       .collect::<Vec<_>>();
     Self { text, lines }
   }

--- a/src/source_content_lines.rs
+++ b/src/source_content_lines.rs
@@ -19,13 +19,7 @@ impl<'object_pool> SourceContentLines<'object_pool> {
       unsafe { std::mem::transmute::<&str, &'static str>(text.as_ref()) };
     let is_ascii = text_ref.is_ascii();
     let lines = split_into_lines(text_ref)
-      .map(|line| {
-        if is_ascii {
-          WithUtf16::with_known(object_pool, line, true)
-        } else {
-          WithUtf16::new(object_pool, line)
-        }
-      })
+      .map(|line| WithUtf16::with_known(object_pool, line, is_ascii))
       .collect::<Vec<_>>();
     Self { text, lines }
   }

--- a/src/with_utf16.rs
+++ b/src/with_utf16.rs
@@ -13,6 +13,7 @@ pub struct WithUtf16<'object_pool, 'text> {
 }
 
 impl<'object_pool, 'text> WithUtf16<'object_pool, 'text> {
+  #[allow(dead_code)]
   pub fn new(object_pool: &'object_pool ObjectPool, line: &'text str) -> Self {
     Self::with_known(object_pool, line, false)
   }
@@ -42,8 +43,17 @@ impl<'object_pool, 'text> WithUtf16<'object_pool, 'text> {
       return "";
     }
 
+    let utf8_len = self.line.len();
+    if self.is_ascii {
+      let start_utf16_index = start_utf16_index.min(utf8_len);
+      let end_utf16_index = end_utf16_index.min(utf8_len);
+      return unsafe {
+        self.line.get_unchecked(start_utf16_index..end_utf16_index)
+      };
+    }
+
     let utf16_byte_indices = self.utf16_byte_indices.get_or_init(|| {
-      if self.is_ascii || self.line.is_ascii() {
+      if self.line.is_ascii() {
         return None;
       }
 
@@ -73,8 +83,6 @@ impl<'object_pool, 'text> WithUtf16<'object_pool, 'text> {
       }
       Some(vec)
     });
-
-    let utf8_len = self.line.len();
 
     let Some(utf16_byte_indices) = utf16_byte_indices else {
       let start_utf16_index = start_utf16_index.min(utf8_len);

--- a/src/with_utf16.rs
+++ b/src/with_utf16.rs
@@ -33,6 +33,7 @@ impl<'object_pool, 'text> WithUtf16<'object_pool, 'text> {
   }
 
   /// substring::SubString with cache
+  #[inline]
   #[allow(unsafe_code)]
   pub fn substring(
     &self,


### PR DESCRIPTION
## Summary

- Optimize source-map mappings encoding with VLQ fast paths and buffer preallocation.
- Write stable source-map JSON manually while still using `simd-json` for arbitrary JSON string escaping.
- Cache `CachedSource` text and avoid materializing cached stream source text until an existing cached map actually needs it.
- Skip `ReplaceSource` chunk rewriting when there are no replacements.
- Reuse ASCII knowledge for source-content line slices and fast path ASCII UTF-16 substring checks.

## Rspack benchmark impact

Measured through the Rspack `threejs-production-sourcemap` CodSpeed CPU simulation benchmark (`RAYON_NUM_THREADS=1` for local comparability; Rayon scheduling cost was not optimized):

| Rspack commit | Accesses Before | Accesses After | Accesses Delta | Estimated Cycles Before | Estimated Cycles After | Estimated Cycles Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `2e41c924be` | 1,184,875,619 | 1,143,132,259 | -41,743,360 (-3.523%) | 1,359,247,384 | 1,318,226,389 | -41,020,995 (-3.018%) |

Local checks: `cargo fmt --check`, `cargo test -q`.